### PR TITLE
Track Max Length of Field Statically

### DIFF
--- a/src/main/scala/com/github/atais/fixedlength/Codec.scala
+++ b/src/main/scala/com/github/atais/fixedlength/Codec.scala
@@ -11,6 +11,7 @@ object Codec {
                              padding: Char = ' ', defaultValue: A = null.asInstanceOf[A]): Codec[A] = {
 
     new Codec[A] {
+      override val maxLength = end.toLong - start.toLong
       override def decode(str: String): Either[Throwable, A] =
         Decoder.decode(str)(Decoder.fixed[A](start, end, align, padding, defaultValue))
 
@@ -20,6 +21,7 @@ object Codec {
   }
 
   val hnilCodec = new Codec[HNil] {
+    val maxLength = 0L
     override def decode(str: String): Either[Throwable, HNil] = Decoder.hnilDecoder.decode(str)
 
     override def encode(obj: HNil): String = Encoder.hnilEncoder.encode(obj)
@@ -27,6 +29,7 @@ object Codec {
 
   final implicit class HListCodecEnrichedWithHListSupport[L <: HList](val self: Codec[L]) extends Serializable {
     def <<:[B](bCodec: Codec[B]): Codec[B :: L] = new Codec[B :: L] {
+      val maxLength = bCodec.maxLength + self.maxLength
 
       override def decode(str: String): Either[Throwable, ::[B, L]] =
         Decoder.merge(self, bCodec, str)
@@ -36,6 +39,7 @@ object Codec {
     }
 
     def as[B](implicit gen: Generic.Aux[B, L]): Codec[B] = new Codec[B] {
+      val maxLength = self.maxLength
       override def decode(str: String): Either[Throwable, B] =
         Decoder.transform(self, str)
 
@@ -48,6 +52,7 @@ object Codec {
     def <<:[B](codecB: Codec[B]): Codec[B :: A :: HNil] = {
 
       val lastCodec = new Codec[A] {
+        val maxLength = codecB.maxLength
         override def decode(str: String): Either[Throwable, A] =
           Decoder.decodeLast(self, str)
 

--- a/src/test/scala/com/github/atais/fixedlength/simple/DecoderTest.scala
+++ b/src/test/scala/com/github/atais/fixedlength/simple/DecoderTest.scala
@@ -31,6 +31,18 @@ class DecoderTest extends FlatSpec with Matchers {
     }.as[Employee]
   }
 
+  it should "track max length correctly for obvious cases" in {
+    import com.github.atais.util.Read._
+    import Decoder._
+
+    val employeeCodecLength: Long = {
+      fixed[String](0, 10) <<:
+        fixed[Option[Int]](10, 13, Alignment.Right) <<:
+        fixed[Boolean](13, 18)
+    }.maxLength
+
+    employeeCodecLength shouldBe 18
+  }
 }
 
 


### PR DESCRIPTION
I have a use case where I have a lot of right padding on any given record. Basically, it'd be nice to be able to truncate to what I care about up front, but it is a bummer to duplicate that state outside the decoders.
Part of me suspects that removing the errors that are thrown when the record is longer than expected would be the more satisfactory position, but this is certainly less invasive.
Basically, the idea is to track the max length of a record through the Shapeless induction and then allow access to that so that users can track ideal usage.
I welcome any suggestions on better design!