### PR TITLE
Update dependencies to cats 2.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ scala:
 jdk:
   - oraclejdk8
 
+dist: trusty
+
 script:
   - sbt clean coverage +test coverageReport
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 # See https://github.com/novus/salat/blob/master/.travis.yml
 language: scala
 scala:
-   - 2.10.6
-   - 2.11.8
-   - 2.12.2
+   - 2.12.15
+   - 2.13.6
 jdk:
   - oraclejdk8
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,28 +1,30 @@
 import sbtrelease.ReleasePlugin.autoImport.ReleaseTransformations._
 
 // main dependencies
-lazy val shapeless = "com.chuusai" %% "shapeless" % "2.3.2"
+lazy val shapeless = "com.chuusai" %% "shapeless" % "2.3.7"
 lazy val shapelessMacros = compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
-lazy val cats = "org.typelevel" %% "cats-core" % "1.1.0"
+lazy val cats = "org.typelevel" %% "cats-core" % "2.0.0"
 
 // test dependencies
-lazy val scalatest = "org.scalatest" %% "scalatest" % "3.0.1" % Test
-lazy val scalacheck = "org.scalacheck" %% "scalacheck" % "1.13.4" % Test
+lazy val scalatest = "org.scalatest" %% "scalatest" % "3.2.10" % Test
+lazy val scalacheck = "org.scalacheck" %% "scalacheck" % "1.15.2" % Test
+lazy val scalatestPlus = "org.scalatestplus" %% "scalacheck-1-15" % "3.2.9.0" % Test
 
 lazy val main = (project in file("."))
   .settings(
 
     name := "fixed-length",
     organization := "com.github.atais",
-    scalaVersion := "2.10.6",
-    crossScalaVersions := Seq("2.10.6", "2.11.8", "2.12.2"),
+    scalaVersion := "2.13.6",
+    crossScalaVersions := Seq("2.12.15", "2.13.6"),
 
     // dependencies
     libraryDependencies ++= Seq(
       shapeless,
       cats,
       scalatest,
-      scalacheck
+      scalacheck,
+      scalatestPlus
     ),
     libraryDependencies ++= (if (scalaBinaryVersion.value startsWith "2.10") Seq(shapelessMacros) else Nil),
 

--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import sbtrelease.ReleasePlugin.autoImport.ReleaseTransformations._
 // main dependencies
 lazy val shapeless = "com.chuusai" %% "shapeless" % "2.3.7"
 lazy val shapelessMacros = compilerPlugin("org.scalamacros" % "paradise" % "2.1.0" cross CrossVersion.full)
-lazy val cats = "org.typelevel" %% "cats-core" % "2.0.0"
+lazy val cats = "org.typelevel" %% "cats-core" % "2.6.1"
 
 // test dependencies
 lazy val scalatest = "org.scalatest" %% "scalatest" % "3.2.10" % Test

--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ lazy val cats = "org.typelevel" %% "cats-core" % "2.0.0"
 // test dependencies
 lazy val scalatest = "org.scalatest" %% "scalatest" % "3.2.10" % Test
 lazy val scalacheck = "org.scalacheck" %% "scalacheck" % "1.15.2" % Test
-lazy val scalatestPlus = "org.scalatestplus" %% "scalacheck-1-15" % "3.2.9.0" % Test
+lazy val scalatestPlus = "org.scalatestplus" %% "scalacheck-1-15" % "3.2.10.0" % Test
 
 lazy val main = (project in file("."))
   .settings(

--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ lazy val cats = "org.typelevel" %% "cats-core" % "2.6.1"
 
 // test dependencies
 lazy val scalatest = "org.scalatest" %% "scalatest" % "3.2.10" % Test
-lazy val scalacheck = "org.scalacheck" %% "scalacheck" % "1.15.2" % Test
+lazy val scalacheck = "org.scalacheck" %% "scalacheck" % "1.15.4" % Test
 lazy val scalatestPlus = "org.scalatestplus" %% "scalacheck-1-15" % "3.2.10.0" % Test
 
 lazy val main = (project in file("."))

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version = 0.13.15
+sbt.version = 1.5.5

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.9.1")
 
-addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.8")
+addSbtPlugin("com.github.sbt" % "sbt-release" % "1.1.0")
 
-addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "2.3")
+addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.9.10")
 
-addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.1.1")
+addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")

--- a/src/test/scala/com/github/atais/fixedlength/DefaultValueTest.scala
+++ b/src/test/scala/com/github/atais/fixedlength/DefaultValueTest.scala
@@ -1,8 +1,10 @@
 package com.github.atais.fixedlength
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class DefaultValueTest extends FlatSpec with Matchers {
+class DefaultValueTest extends AnyFlatSpec with Matchers with EitherValues {
 
   val defaultValue = 0
 
@@ -28,7 +30,7 @@ class DefaultValueTest extends FlatSpec with Matchers {
     val exampleString = "12"
     val decoded = Parser.decode[Example](exampleString)
 
-    decoded.right.get.c shouldEqual defaultValue
+    decoded.value.c shouldEqual defaultValue
   }
 
 

--- a/src/test/scala/com/github/atais/fixedlength/GenericCodecTest.scala
+++ b/src/test/scala/com/github/atais/fixedlength/GenericCodecTest.scala
@@ -1,9 +1,11 @@
 package com.github.atais.fixedlength
 
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-class GenericCodecTest extends FlatSpec with Matchers with PropertyChecks {
+class GenericCodecTest extends AnyFlatSpec with Matchers with ScalaCheckPropertyChecks with EitherValues {
 
   implicit val generatorDrivenConf = PropertyCheckConfiguration(minSuccessful = 5000)
 
@@ -35,7 +37,7 @@ class GenericCodecTest extends FlatSpec with Matchers with PropertyChecks {
         encoded shouldEqual stringed
 
         val decoded = Parser.decode[Example](encoded)
-        decoded.right.get shouldEqual m
+        decoded.value shouldEqual m
       }
     }
     }

--- a/src/test/scala/com/github/atais/fixedlength/MultipleCodecTest.scala
+++ b/src/test/scala/com/github/atais/fixedlength/MultipleCodecTest.scala
@@ -1,8 +1,10 @@
 package com.github.atais.fixedlength
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class MultipleCodecTest extends FlatSpec with Matchers {
+class MultipleCodecTest extends AnyFlatSpec with Matchers with EitherValues {
 
   case class Example1(a: String, b: String, c: String)
 
@@ -49,9 +51,9 @@ class MultipleCodecTest extends FlatSpec with Matchers {
     // implicits should be working here
     import Example1._
     import Example2._
-    Parser.decode[Example1](ex1S).right.get shouldEqual ex1
+    Parser.decode[Example1](ex1S).value shouldEqual ex1
     Parser.encode[Example1](ex1) shouldEqual ex1S
-    Parser.decode[Example2](ex2S).right.get shouldEqual ex2
+    Parser.decode[Example2](ex2S).value shouldEqual ex2
     Parser.encode[Example2](ex2) shouldEqual ex2S
   }
 

--- a/src/test/scala/com/github/atais/fixedlength/ParsingErrorsTest.scala
+++ b/src/test/scala/com/github/atais/fixedlength/ParsingErrorsTest.scala
@@ -1,8 +1,10 @@
 package com.github.atais.fixedlength
 
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class ParsingErrorsTest extends FlatSpec with Matchers {
+class ParsingErrorsTest extends AnyFlatSpec with Matchers with EitherValues {
 
   case class Example(a: Int, b: Int, c: Int)
 
@@ -26,8 +28,8 @@ class ParsingErrorsTest extends FlatSpec with Matchers {
     val exampleString = "12"
     val decoded = Parser.decode[Example](exampleString)
 
-    decoded.left.get shouldBe a[StringIndexOutOfBoundsException]
-    decoded.right.toOption shouldEqual None
+    decoded.left.value shouldBe a[StringIndexOutOfBoundsException]
+    decoded.toOption shouldEqual None
   }
 
   it should "return an ParsingFailedException error if input does not match expected types" in {
@@ -36,9 +38,9 @@ class ParsingErrorsTest extends FlatSpec with Matchers {
     val exampleString = "12-"
     val decoded = Parser.decode[Example](exampleString)
 
-    decoded.left.get shouldBe a[ParsingFailedException]
-    decoded.left.get.getMessage should include("-")
-    decoded.right.toOption shouldEqual None
+    decoded.left.value shouldBe a[ParsingFailedException]
+    decoded.left.value.getMessage should include("-")
+    decoded.toOption shouldEqual None
   }
 
   it should "return an LineLongerThanExpectedException error if input line is longer than expected" in {
@@ -47,9 +49,9 @@ class ParsingErrorsTest extends FlatSpec with Matchers {
     val exampleString = "1234"
     val decoded = Parser.decode[Example](exampleString)
 
-    decoded.left.get shouldBe a[LineLongerThanExpectedException]
-    decoded.left.get.getMessage should include(exampleString)
-    decoded.right.toOption shouldEqual None
+    decoded.left.value shouldBe a[LineLongerThanExpectedException]
+    decoded.left.value.getMessage should include(exampleString)
+    decoded.toOption shouldEqual None
   }
 
 

--- a/src/test/scala/com/github/atais/fixedlength/simple/CodecTest.scala
+++ b/src/test/scala/com/github/atais/fixedlength/simple/CodecTest.scala
@@ -1,15 +1,17 @@
 package com.github.atais.fixedlength.simple
 
 import com.github.atais.fixedlength.{Alignment, Codec, Parser}
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class CodecTest extends FlatSpec with Matchers {
+class CodecTest extends AnyFlatSpec with Matchers with EitherValues {
 
   behavior of "Codec"
 
   it should "decode example object properly" in {
     import Employee._
-    Parser.decode[Employee](exampleString).right.get shouldEqual exampleObject
+    Parser.decode[Employee](exampleString).value shouldEqual exampleObject
   }
 
   it should "encode example object properly" in {

--- a/src/test/scala/com/github/atais/fixedlength/simple/DecoderTest.scala
+++ b/src/test/scala/com/github/atais/fixedlength/simple/DecoderTest.scala
@@ -1,15 +1,17 @@
 package com.github.atais.fixedlength.simple
 
 import com.github.atais.fixedlength.{Alignment, Decoder, Parser}
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.EitherValues
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class DecoderTest extends FlatSpec with Matchers {
+class DecoderTest extends AnyFlatSpec with Matchers with EitherValues {
 
   behavior of "Decoder"
 
   it should "decode example object properly" in {
     import Employee._
-    Parser.decode[Employee](exampleString).right.get shouldEqual exampleObject
+    Parser.decode[Employee](exampleString).value shouldEqual exampleObject
   }
 
   // this will not compile due to lacking Encoder

--- a/src/test/scala/com/github/atais/fixedlength/simple/EncoderTest.scala
+++ b/src/test/scala/com/github/atais/fixedlength/simple/EncoderTest.scala
@@ -1,9 +1,10 @@
 package com.github.atais.fixedlength.simple
 
 import com.github.atais.fixedlength.{Alignment, Encoder, Parser}
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-class EncoderTest extends FlatSpec with Matchers {
+class EncoderTest extends AnyFlatSpec with Matchers {
 
   behavior of "Encoder"
 

--- a/src/test/scala/com/github/atais/read/ReadersTest.scala
+++ b/src/test/scala/com/github/atais/read/ReadersTest.scala
@@ -1,10 +1,11 @@
 package com.github.atais.read
 
 import com.github.atais.util.Read._
-import org.scalatest.prop.PropertyChecks
-import org.scalatest.{FlatSpec, Matchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatestplus.scalacheck.ScalaCheckPropertyChecks
 
-class ReadersTest extends FlatSpec with Matchers with PropertyChecks {
+class ReadersTest extends AnyFlatSpec with Matchers with ScalaCheckPropertyChecks {
 
   implicit val generatorDrivenConf = PropertyCheckConfiguration(minSuccessful = 5000)
 
@@ -37,7 +38,7 @@ class ReadersTest extends FlatSpec with Matchers with PropertyChecks {
   }
 
   "Any string" should "be parsed properly" in {
-    forAll { m: String => test(stringRead.read(m.toString), m) }
+    forAll { m: String => test(stringRead.read(m), m) }
   }
 
   private def test[A](returned: Either[Throwable, A], checkValue: A) = {

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.4.1"
+ThisBuild / version := "0.4.1"


### PR DESCRIPTION
I've updated all dependencies as I want to use this library from a Scala 2.13 project. Unfortunately that meant dropping support for scala 2.10 and 2.11.

Lmk what you think